### PR TITLE
Revert "chore(deps): update openjdk docker tag to v17"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM openjdk:12-alpine
 
 # redpen
 ENV REDPEN_VERSION=1.10.4


### PR DESCRIPTION
This reverts commit 22797d57864f659f622a78a65be55c284d214a4d.

## related issue

close #53 

not work v17, need current version

