### PR TITLE
fix: git error introduced in git 2.35.2

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [ -n "${GITHUB_WORKSPACE}" ] ; then
   cd "${GITHUB_WORKSPACE}" || exit
 fi
-
+git config --global --add safe.directory $GITHUB_WORKSPACE || exit 1
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 redpen --version

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,9 @@ set -e
 
 if [ -n "${GITHUB_WORKSPACE}" ] ; then
   cd "${GITHUB_WORKSPACE}" || exit
+  git config --global --add safe.directory $GITHUB_WORKSPACE || exit 1
 fi
-git config --global --add safe.directory $GITHUB_WORKSPACE || exit 1
+
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 redpen --version


### PR DESCRIPTION
# Pull Request detail
Git v2.35.2 spec changes are causing this action to error during run.

`reviewdog: PullRequest needs 'git' command: failed to run 'git rev-parse --show-prefix': exit status 128`

## Related issues or PRs/関連issueやPR

https://github.com/reviewdog/action-misspell/issues/43
https://github.com/reviewdog/action-misspell/issues/42
https://github.com/reviewdog/reviewdog/issues/1158#issue-1202862728
https://github.com/reviewdog/action-yamllint/issues/18

close #.

## Fix or Add/Remove in this PR/このプルリクエストでやったこと

- ...

## Do not fix or add/remove this PR/このプルリクエストでやらなかったこと

- ...

## Pros and Cons/メリットとデメリット

- ...

## Test/動作確認

Test item list up with checkbox, checked after tested./チェックボックス式にし、確認後チェックする。

- [ ] ...

